### PR TITLE
Update API_URL to the target of the redirection.

### DIFF
--- a/lib/semaphore-status.rb
+++ b/lib/semaphore-status.rb
@@ -8,7 +8,7 @@ require 'time'
 
 class SemaphoreClient
 
-  API_URL = 'https://semaphoreapp.com/api/v1/projects?auth_token='
+  API_URL = 'https://semaphoreci.com/api/v1/projects?auth_token='
 
   def initialize(token)
       response = open(API_URL+token).read


### PR DESCRIPTION
`open-uri` does not appreciate the redirect from `semaphoreapp.com` to `semaphoreci.com`, so we can just go to the latter in the first place.

Closes issue #4.
